### PR TITLE
Changes -q and --query to -f and --f

### DIFF
--- a/features/static-queries.feature
+++ b/features/static-queries.feature
@@ -15,7 +15,7 @@ Scenario: A Successful Query
   When I run gurl with the following arguments:
       | flag  | value                                |
       | -u    | https://www.moonhighway.com/graphiql |
-      | -q    | sample-query.txt                     |
+      | -f    | sample-query.txt                     |
   Then I should see the following results in the terminal:
       """
       {
@@ -73,7 +73,7 @@ Given the query file "sample-query.txt":
 When I run gurl with the following arguments:
     | flag     | value                                |
     | --url    | https://www.moonhighway.com/graphiql |
-    | --query  | sample-query.txt                     |
+    | --file   | sample-query.txt                     |
 Then I should see the following results in the terminal:
     """
     {
@@ -126,7 +126,7 @@ Scenario: Query Not Provided
     """
 
       Error: A graph query file was not provided.
-        Please provide a query file with -q or --query.
+        Please provide a query file with -f or --file.
 
     """
   And the application should exit with an error.
@@ -135,7 +135,7 @@ Scenario: File Not Found
   When I run gurl with the following arguments:
     | flag  | value                                |
     | -u    | https://www.moonhighway.com/graphiql |
-    | -q    | file-not-there.txt                   |
+    | -f    | file-not-there.txt                   |
   Then I should see the following results in the terminal:
     """
 
@@ -156,7 +156,7 @@ Given the query file "sample-query.txt":
   """
 When I run gurl with the following arguments:
   | flag  | value            |
-  | -q    | sample-query.txt |
+  | -f    | sample-query.txt |
 Then I should see the following results in the terminal:
   """
 
@@ -178,7 +178,7 @@ Scenario: URL Not a Graph Endpoint
   When I run gurl with the following arguments:
     | flag  | value                       |
     | -u    | https://www.moonhighway.com |
-    | -q    | sample-query.txt            |
+    | -f    | sample-query.txt            |
   Then I should see the following results in the terminal:
     """
 
@@ -198,7 +198,7 @@ Scenario: Graph Errors
   When I run gurl with the following arguments:
     | flag  | value                                |
     | -u    | https://www.moonhighway.com/graphiql |
-    | -q    | sample-query.txt                     |
+    | -f    | sample-query.txt                     |
   Then I should see the following results in the terminal:
     """
 

--- a/features/static-queries.feature
+++ b/features/static-queries.feature
@@ -3,220 +3,277 @@ Feature: Static Queries
   against a graph endpoint
   so that I can see the results in my terminal.
 
-Scenario: A Successful Query
-  Given the query file "sample-query.txt":
-    """
-    {
-      allLifts {
-        name
+  Scenario: A Successful Query
+    Given the query file "sample-query.txt":
+      """
+      {
+        allLifts {
+          name
+        }
       }
-    }
-    """
-  When I run gurl with the following arguments:
+      """
+    When I run gurl with the following arguments:
+        | flag  | value                                |
+        | -u    | https://www.moonhighway.com/graphiql |
+        | -f    | sample-query.txt                     |
+    Then I should see the following results in the terminal:
+        """
+        {
+          "data": {
+            "allLifts": [
+              {
+                "name": "Astra Express"
+              },
+              {
+                "name": "Jazz Cat"
+              },
+              {
+                "name": "Jolly Roger"
+              },
+              {
+                "name": "Neptune Rope"
+              },
+              {
+                "name": "Panorama"
+              },
+              {
+                "name": "Prickly Peak"
+              },
+              {
+                "name": "Snowtooth Express"
+              },
+              {
+                "name": "Summit"
+              },
+              {
+                "name": "Wally's"
+              },
+              {
+                "name": "Western States"
+              },
+              {
+                "name": "Whirlybird"
+              }
+            ]
+          }
+        }
+        """
+  And the application should successfully exit.
+
+  Scenario: Optional Feature Flags --file
+    Given the query file "sample-query.txt":
+      """
+      {
+        allLifts {
+          name
+        }
+      }
+      """
+    When I run gurl with the following arguments:
+        | flag     | value                                |
+        | --url    | https://www.moonhighway.com/graphiql |
+        | --file   | sample-query.txt                     |
+    Then I should see the following results in the terminal:
+        """
+        {
+          "data": {
+            "allLifts": [
+              {
+                "name": "Astra Express"
+              },
+              {
+                "name": "Jazz Cat"
+              },
+              {
+                "name": "Jolly Roger"
+              },
+              {
+                "name": "Neptune Rope"
+              },
+              {
+                "name": "Panorama"
+              },
+              {
+                "name": "Prickly Peak"
+              },
+              {
+                "name": "Snowtooth Express"
+              },
+              {
+                "name": "Summit"
+              },
+              {
+                "name": "Wally's"
+              },
+              {
+                "name": "Western States"
+              },
+              {
+                "name": "Whirlybird"
+              }
+            ]
+          }
+        }
+        """
+    And the application should successfully exit.
+
+
+  Scenario: Optional Feature Flags --fileName
+    Given the query file "sample-query.txt":
+      """
+      {
+        allLifts {
+          name
+        }
+      }
+      """
+    When I run gurl with the following arguments:
+        | flag       | value                                |
+        | --url      | https://www.moonhighway.com/graphiql |
+        | --fileName | sample-query.txt                     |
+    Then I should see the following results in the terminal:
+        """
+        {
+          "data": {
+            "allLifts": [
+              {
+                "name": "Astra Express"
+              },
+              {
+                "name": "Jazz Cat"
+              },
+              {
+                "name": "Jolly Roger"
+              },
+              {
+                "name": "Neptune Rope"
+              },
+              {
+                "name": "Panorama"
+              },
+              {
+                "name": "Prickly Peak"
+              },
+              {
+                "name": "Snowtooth Express"
+              },
+              {
+                "name": "Summit"
+              },
+              {
+                "name": "Wally's"
+              },
+              {
+                "name": "Western States"
+              },
+              {
+                "name": "Whirlybird"
+              }
+            ]
+          }
+        }
+        """
+    And the application should successfully exit.
+
+  Scenario: Query Not Provided
+    When I run gurl with the following arguments:
+    | flag  | value                                |
+    | -u    | https://www.moonhighway.com/graphiql |
+    Then I should see the following results in the terminal:
+      """
+
+        Error: A graph query file was not provided.
+          Please provide a query file with -f or --file.
+
+      """
+    And the application should exit with an error.
+
+  Scenario: File Not Found
+    When I run gurl with the following arguments:
+      | flag  | value                                |
+      | -u    | https://www.moonhighway.com/graphiql |
+      | -f    | file-not-there.txt                   |
+    Then I should see the following results in the terminal:
+      """
+
+        Error: Query file not found!
+          Please check the query file name and path.
+
+      """
+    And the application should exit with an error.
+
+  Scenario: URL Not Provided
+    Given the query file "sample-query.txt":
+      """
+      {
+        allLifts {
+          name
+        }
+      }
+      """
+    When I run gurl with the following arguments:
+      | flag  | value            |
+      | -f    | sample-query.txt |
+    Then I should see the following results in the terminal:
+      """
+
+        Error: A GraphQL Endpoint URL not provided.
+          Please provide an endpoint url with -u or --url.
+
+      """
+    And the application should exit with an error.
+
+  Scenario: URL Not a Graph Endpoint
+    Given the query file "sample-query.txt":
+      """
+      {
+        allLifts {
+          name
+        }
+      }
+      """
+    When I run gurl with the following arguments:
+      | flag  | value                       |
+      | -u    | https://www.moonhighway.com |
+      | -f    | sample-query.txt            |
+    Then I should see the following results in the terminal:
+      """
+
+        Error: URL does not accept graph queries.
+          The GraphQL endpoint url provided does not accept queries.
+
+      """
+    And the application should exit with an error.
+
+  Scenario: Graph Errors
+    Given the query file "sample-query.txt":
+      """
+      {
+        notThere
+      }
+      """
+    When I run gurl with the following arguments:
       | flag  | value                                |
       | -u    | https://www.moonhighway.com/graphiql |
       | -f    | sample-query.txt                     |
-  Then I should see the following results in the terminal:
+    Then I should see the following results in the terminal:
       """
+
+        Error: GraphQL Error
+          The server responded with the following error:
       {
-        "data": {
-          "allLifts": [
-            {
-              "name": "Astra Express"
-            },
-            {
-              "name": "Jazz Cat"
-            },
-            {
-              "name": "Jolly Roger"
-            },
-            {
-              "name": "Neptune Rope"
-            },
-            {
-              "name": "Panorama"
-            },
-            {
-              "name": "Prickly Peak"
-            },
-            {
-              "name": "Snowtooth Express"
-            },
-            {
-              "name": "Summit"
-            },
-            {
-              "name": "Wally's"
-            },
-            {
-              "name": "Western States"
-            },
-            {
-              "name": "Whirlybird"
-            }
-          ]
-        }
-      }
-      """
-And the application should successfully exit.
-
-Scenario: Optional Feature Flags
-
-Given the query file "sample-query.txt":
-  """
-  {
-    allLifts {
-      name
-    }
-  }
-  """
-When I run gurl with the following arguments:
-    | flag     | value                                |
-    | --url    | https://www.moonhighway.com/graphiql |
-    | --file   | sample-query.txt                     |
-Then I should see the following results in the terminal:
-    """
-    {
-      "data": {
-        "allLifts": [
+        "errors": [
           {
-            "name": "Astra Express"
-          },
-          {
-            "name": "Jazz Cat"
-          },
-          {
-            "name": "Jolly Roger"
-          },
-          {
-            "name": "Neptune Rope"
-          },
-          {
-            "name": "Panorama"
-          },
-          {
-            "name": "Prickly Peak"
-          },
-          {
-            "name": "Snowtooth Express"
-          },
-          {
-            "name": "Summit"
-          },
-          {
-            "name": "Wally's"
-          },
-          {
-            "name": "Western States"
-          },
-          {
-            "name": "Whirlybird"
+            "message": "Cannot query field \"notThere\" on type \"Query\".",
+            "locations": [
+              {
+                "line": 2,
+                "column": 3
+              }
+            ]
           }
         ]
-      }
-    }
-    """
-And the application should successfully exit.
+     }
 
-Scenario: Query Not Provided
-  When I run gurl with the following arguments:
-  | flag  | value                                |
-  | -u    | https://www.moonhighway.com/graphiql |
-  Then I should see the following results in the terminal:
-    """
-
-      Error: A graph query file was not provided.
-        Please provide a query file with -f or --file.
-
-    """
-  And the application should exit with an error.
-
-Scenario: File Not Found
-  When I run gurl with the following arguments:
-    | flag  | value                                |
-    | -u    | https://www.moonhighway.com/graphiql |
-    | -f    | file-not-there.txt                   |
-  Then I should see the following results in the terminal:
-    """
-
-      Error: Query file not found!
-        Please check the query file name and path.
-
-    """
-  And the application should exit with an error.
-
-Scenario: URL Not Provided
-Given the query file "sample-query.txt":
-  """
-  {
-    allLifts {
-      name
-    }
-  }
-  """
-When I run gurl with the following arguments:
-  | flag  | value            |
-  | -f    | sample-query.txt |
-Then I should see the following results in the terminal:
-  """
-
-    Error: A GraphQL Endpoint URL not provided.
-      Please provide an endpoint url with -u or --url.
-
-  """
-And the application should exit with an error.
-
-Scenario: URL Not a Graph Endpoint
-  Given the query file "sample-query.txt":
-    """
-    {
-      allLifts {
-        name
-      }
-    }
-    """
-  When I run gurl with the following arguments:
-    | flag  | value                       |
-    | -u    | https://www.moonhighway.com |
-    | -f    | sample-query.txt            |
-  Then I should see the following results in the terminal:
-    """
-
-      Error: URL does not accept graph queries.
-        The GraphQL endpoint url provided does not accept queries.
-
-    """
-  And the application should exit with an error.
-
-Scenario: Graph Errors
-  Given the query file "sample-query.txt":
-    """
-    {
-      notThere
-    }
-    """
-  When I run gurl with the following arguments:
-    | flag  | value                                |
-    | -u    | https://www.moonhighway.com/graphiql |
-    | -f    | sample-query.txt                     |
-  Then I should see the following results in the terminal:
-    """
-
-      Error: GraphQL Error
-        The server responded with the following error:
-    {
-      "errors": [
-        {
-          "message": "Cannot query field \"notThere\" on type \"Query\".",
-          "locations": [
-            {
-              "line": 2,
-              "column": 3
-            }
-          ]
-        }
-      ]
-   }
-
-    """
-  And the application should exit with an error.
+      """
+    And the application should exit with an error.

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import {
 const readFile = Promise.promisify(fs.readFile)
 const argv = minimist(process.argv.slice(2))
 const graphEndpoint = argv.u || argv.url
-const queryFileName = argv.f || argv.file
+const queryFileName = argv.f || argv.fileName || argv.file
 
 if (!graphEndpoint) {
   errorExit(

--- a/src/index.js
+++ b/src/index.js
@@ -12,14 +12,7 @@ import {
 const readFile = Promise.promisify(fs.readFile)
 const argv = minimist(process.argv.slice(2))
 const graphEndpoint = argv.u || argv.url
-const queryFileName = argv.q || argv.query
-
-if (!queryFileName) {
-  errorExit(
-    'A graph query file was not provided.',
-    'Please provide a query file with -q or --query.'
-  )
-}
+const queryFileName = argv.f || argv.file
 
 if (!graphEndpoint) {
   errorExit(
@@ -28,8 +21,15 @@ if (!graphEndpoint) {
   )
 }
 
+if (!queryFileName) {
+  errorExit(
+    'A graph query file was not provided.',
+    'Please provide a query file with -f or --file.'
+  )
+}
+
 readFile(queryFileName, "UTF-8")
-  .then(query => fetch(`${graphEndpoint}?query=${query}`))
+  .then(q => fetch(`${graphEndpoint}?query=${q}`))
   .then(checkJSONHeader)
   .then(res => res.json())
   .then(checkGraphQLError)


### PR DESCRIPTION
This PR changes the -q and --query flags to -f and --f for the queryFile.

Here is my thinking: maybe -q and --query should be used to define the name of a query to run. For instance, if the query file defines 3 queries, than you can select the query that you wish to run using the -q flag.